### PR TITLE
Update LinoDialog.js DomHandler import

### DIFF
--- a/lino_react/react/components/LinoDialog.js
+++ b/lino_react/react/components/LinoDialog.js
@@ -12,7 +12,7 @@ import {Dialog} from 'primereact/dialog';
 import {SiteContext, ActorContext} from "./SiteContext";
 import LinoLayout from "./LinoComponents";
 import LinoBbar from "./LinoBbar";
-import DomHandler from "../../../../primereact/src/components/utils/DomHandler";
+import { DomHandler } from "primereact/domhandler";
 
 // better onOpen focusing logic.
 Dialog.prototype.focus = function focus() {


### PR DESCRIPTION
import { DomHandler } from "primereact/domhandler" ;
used instead of 
import DomHandler from "../../../../primereact/src/components/utils/DomHandler";
which depends on custom directory structure